### PR TITLE
Minor pre-release cleanups

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -2,9 +2,9 @@
 #
 # Authors: Carsten Agger (carstena@magenta-aps.dk), and others.
 #
-# This directory contains the OS2BorgerPC Server Image project.
+# This directory contains the OS2borgerPC Server Image project.
 #
-# The OS2BorgerPC Server Image is free software: you can redistribute it
+# The OS2borgerPC Server Image is free software: you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.

--- a/README
+++ b/README
@@ -1,12 +1,12 @@
 This folder contains the source code for building a modified Ubuntu
 Server image (.iso file) for connection server installations to the
-OS2BorgerPC admin system.
+OS2borgerPC admin system.
 
-This work was commissioned by Aarhus Kommune for their OS2Display
-solution. The image contains an install script for the OS2BorgerPC
+This work was commissioned by Aarhus Kommune for their OS2display
+solution. The image contains an install script for the OS2borgerPC
 client as well as some utilities to easily connect to the network in
 case no Internet is available during installation.
 
-The OS2BorgerPC Server Image is free software, and you are welcome to
+The OS2borgerPC Server Image is free software, and you are welcome to
 use, study, modify and distribute it under the terms of version 3 of the
 GNU General Public License.

--- a/image/scripts/make_bootable_iso.sh
+++ b/image/scripts/make_bootable_iso.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+ead() {
+    echo "$@" && "$@"
+}
+
+usage() {
+    echo "Usage: $0 DIRECTORY [VOLUME-LABEL]"
+    exit 1
+}
+
+IMAGE_DIR="${1%%/}"
+if [ "$IMAGE_DIR" = "" ]; then
+    usage
+fi
+if [ "$2" != "" ]; then
+    IMAGE_LABEL="$2"
+else
+    IMAGE_LABEL="$IMAGE_DIR"
+fi
+
+if [ ! -d "$IMAGE_DIR" ]; then
+    echo "$0: the directory \"$IMAGE_DIR\" does not exist" 1>&2
+    exit 1
+else
+    # -JR makes the image have Windows- and POSIX-compatible metadata to make
+    # the filesystem behave more normally
+    ead genisoimage \
+        -o "$IMAGE_LABEL.iso" -V "$IMAGE_LABEL" \
+        -iso-level 4 -JR \
+        -c isolinux/boot.cat -b isolinux/isolinux.bin \
+            -no-emul-boot -boot-load-size 4 -boot-info-table \
+        -eltorito-alt-boot \
+            -e boot/grub/efi.img -no-emul-boot \
+        "$IMAGE_DIR/" && ead isohybrid "$IMAGE_LABEL.iso"
+fi

--- a/image/ubuntu-image/boot/grub/grub.cfg
+++ b/image/ubuntu-image/boot/grub/grub.cfg
@@ -1,0 +1,76 @@
+
+if loadfont /boot/grub/font.pf2 ; then
+	set gfxmode=auto
+	insmod efi_gop
+	insmod efi_uga
+	insmod gfxterm
+	terminal_output gfxterm
+fi
+
+set menu_color_normal=white/black
+set menu_color_highlight=black/light-gray
+
+menuentry "Install Ubuntu Server for OS2display" {
+	set gfxpayload=keep
+        linux	/install/vmlinuz  file=/cdrom/preseed/ubuntu-server.seed quiet debian-installer/locale=da_DK.UTF-8  priority=critical ---
+	initrd	/install/initrd.gz
+}
+menuentry "OEM install (for manufacturers)" {
+	set gfxpayload=keep
+	linux	/install/vmlinuz  file=/cdrom/preseed/ubuntu-server.seed quiet oem-config/enable=true ---
+	initrd	/install/initrd.gz
+}
+menuentry "Install MAAS Region Controller" {
+	set gfxpayload=keep
+	linux	/install/vmlinuz  modules=maas-region-udeb vga=788 initrd=/install/initrd.gz quiet ---
+	initrd	/install/initrd.gz
+}
+
+menuentry "Install MAAS Rack Controller" {
+	set gfxpayload=keep
+	linux	/install/vmlinuz  modules=maas-rack-udeb vga=788 initrd=/install/initrd.gz quiet ---
+	initrd	/install/initrd.gz
+}
+menuentry "Check disc for defects" {
+	set gfxpayload=keep
+	linux	/install/vmlinuz  MENU=/bin/cdrom-checker-menu quiet ---
+	initrd	/install/initrd.gz
+}
+menuentry "Rescue a broken system" {
+	set gfxpayload=keep
+	linux	/install/vmlinuz  rescue/enable=true ---
+	initrd	/install/initrd.gz
+}
+submenu 'Boot and Install with the HWE kernel' {
+menuentry "Install Ubuntu Server" {
+	set gfxpayload=keep
+	linux	/install/hwe-vmlinuz  file=/cdrom/preseed/hwe-ubuntu-server.seed quiet ---
+	initrd	/install/hwe-initrd.gz
+}
+menuentry "OEM install (for manufacturers)" {
+	set gfxpayload=keep
+	linux	/install/hwe-vmlinuz  file=/cdrom/preseed/hwe-ubuntu-server.seed quiet oem-config/enable=true ---
+	initrd	/install/hwe-initrd.gz
+}
+menuentry "Install MAAS Region Controller" {
+	set gfxpayload=keep
+	linux	/install/hwe-vmlinuz  modules=maas-region-udeb vga=788 initrd=/install/hwe-initrd.gz quiet ---
+	initrd	/install/hwe-initrd.gz
+}
+
+menuentry "Install MAAS Rack Controller" {
+	set gfxpayload=keep
+	linux	/install/hwe-vmlinuz  modules=maas-rack-udeb vga=788 initrd=/install/hwe-initrd.gz quiet ---
+	initrd	/install/hwe-initrd.gz
+}
+menuentry "Check disc for defects" {
+	set gfxpayload=keep
+	linux	/install/hwe-vmlinuz  MENU=/bin/cdrom-checker-menu quiet ---
+	initrd	/install/hwe-initrd.gz
+}
+menuentry "Rescue a broken system" {
+	set gfxpayload=keep
+	linux	/install/hwe-vmlinuz  rescue/enable=true ---
+	initrd	/install/hwe-initrd.gz
+}
+}

--- a/image/ubuntu-image/isolinux/txt.cfg
+++ b/image/ubuntu-image/isolinux/txt.cfg
@@ -1,6 +1,6 @@
 default install
 label install
-  menu label ^Install Ubuntu Server for OS2 Display
+  menu label ^Install Ubuntu Server for OS2display
   kernel /install/vmlinuz
   append  file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz quiet debian-installer/locale=da_DK.UTF-8  priority=critical ---
 label hwe-install


### PR DESCRIPTION
This branch adds an appropriate command line and caption for the EFI installer, as well as an ISO creation script that sets the right magic values to make the resulting image bootable as an EFI volume.

(It also corrects all instances of `OS2 Display` and `OS2BorgerPC` to the standard `OS2lowercasename` visual identity, for which I can only apologise.)

![p](https://user-images.githubusercontent.com/45562185/73744100-58bda200-4750-11ea-80fc-6512cc3a6334.png)
